### PR TITLE
Change URL for getAllPhoneNumbers

### DIFF
--- a/lib/conferences.js
+++ b/lib/conferences.js
@@ -10,7 +10,7 @@ const ovh = require('ovh')({
 
 const OVHAPIHelper = {
   getAllPhoneNumbers : async () => {
-    const url = '/telephony/aliases'
+    const url = `/telephony/${config.OVH_ACCOUNT_NUMBER}/conference`
 
     try {
       const result = await ovh.requestPromised('GET', url, {})


### PR DESCRIPTION
This only gets numbers for the billingAccount, and doesn't return the weird number blocks. (I left the filtering anyway, just in case...)

Edit : you also only get numbers that have conference configuration (tested by de-conferencing a number)