### PR TITLE
Fix a bug when canceling expired conf

### DIFF
--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -54,7 +54,7 @@ module.exports.showConf = async (req, res) => {
   const confId = req.params.id
 
   try {
-    const conference = await db.getConference(confId)
+    const conference = await db.getUnexpiredConference(confId)
 
     if (conference.canceledAt) {
       req.flash('error', `La conférence a été annulée le ${format.formatFrenchDate(conference.canceledAt)}. Si vous avez encore besoin d\'une conférence, vous pouvez en créer une nouvelle.`)

--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -85,7 +85,13 @@ module.exports.showConf = async (req, res) => {
 module.exports.cancelConf = async (req, res) => {
   const confId = req.params.id
   try {
-    const conference = await db.cancelConference(confId)
+    const conference = module.exports.getConference(id)
+    if (!conference || conference.expiresAt > new Date()) {
+      req.flash('error', 'La conférence a expiré. Vous pouvez recréer une conférence.')
+      return res.redirect('/')
+    }
+
+    await db.cancelConference(confId)
 
     req.flash('success', 'La conférence a bien été annulée. Si vous avez encore besoin d\'une conférence, vous pouvez en créer une nouvelle.')
     console.log(`La conférence ${confId} a été annulée`)

--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -75,7 +75,7 @@ module.exports.showConf = async (req, res) => {
       conference
     })
   } catch (error) {
-    req.flash('error', 'La conférence a expiré. Vous pouvez recréer une conférence.')
+    req.flash('error', 'Une erreur s\'est produite. Vous pouvez recréer une conférence.')
     console.error('showConf error', error)
     return res.redirect('/')
   }
@@ -85,8 +85,8 @@ module.exports.showConf = async (req, res) => {
 module.exports.cancelConf = async (req, res) => {
   const confId = req.params.id
   try {
-    const conference = module.exports.getConference(id)
-    if (!conference || conference.expiresAt > new Date()) {
+    const conference = await db.getConference(confId)
+    if (!conference || conference.expiresAt < new Date()) {
       req.flash('error', 'La conférence a expiré. Vous pouvez recréer une conférence.')
       return res.redirect('/')
     }

--- a/controllers/createConfController.js
+++ b/controllers/createConfController.js
@@ -54,7 +54,12 @@ module.exports.showConf = async (req, res) => {
   const confId = req.params.id
 
   try {
-    const conference = await db.getUnexpiredConference(confId)
+    const conference = await db.getConference(confId)
+
+    if (conference.expiresAt < new Date()) {
+      req.flash('error', 'La conférence a expiré. Vous pouvez recréer une conférence.')
+      return res.redirect('/')
+    }
 
     if (conference.canceledAt) {
       req.flash('error', `La conférence a été annulée le ${format.formatFrenchDate(conference.canceledAt)}. Si vous avez encore besoin d\'une conférence, vous pouvez en créer une nouvelle.`)

--- a/lib/db.js
+++ b/lib/db.js
@@ -116,11 +116,6 @@ module.exports.getUnexpiredConference = async (id) => {
 
 module.exports.cancelConference = async (id) => {
     try {
-        const conference = module.exports.getUnexpiredConference(id)
-        if(!conference) {
-            console.error(`Impossible de récupérer la conférence ${id}`)
-            throw new Error('Impossible de récupérer la conférence')
-        }
         const updatedConference = (await knex('conferences')
             .where({ id: id })
             .update({ canceledAt: knex.fn.now() })

--- a/lib/db.js
+++ b/lib/db.js
@@ -91,7 +91,7 @@ module.exports.insertConference = async (email, phoneNumber, durationInMinutes, 
     }
 }
 
-module.exports.getConference = async (id) => {
+module.exports.getUnexpiredConference = async (id) => {
     try {
         const conferences = await knex('conferences').select()
             .where({ id: id })
@@ -105,7 +105,7 @@ module.exports.getConference = async (id) => {
 
 module.exports.cancelConference = async (id) => {
     try {
-        const conference = module.exports.getConference(id)
+        const conference = module.exports.getUnexpiredConference(id)
         if(!conference) {
             console.error(`Impossible de récupérer la conférence ${id}`)
             throw new Error('Impossible de récupérer la conférence')

--- a/lib/db.js
+++ b/lib/db.js
@@ -91,6 +91,17 @@ module.exports.insertConference = async (email, phoneNumber, durationInMinutes, 
     }
 }
 
+module.exports.getConference = async (id) => {
+    try {
+        const conferences = await knex('conferences').select()
+            .where({ id: id })
+        return conferences[0]
+    } catch (err) {
+      console.error(`Impossible de récupérer la conférence ${id}`, err)
+      throw new Error('Impossible de récupérer la conférence')
+    }
+}
+
 module.exports.getUnexpiredConference = async (id) => {
     try {
         const conferences = await knex('conferences').select()

--- a/lib/db.js
+++ b/lib/db.js
@@ -109,7 +109,7 @@ module.exports.cancelConference = async (id) => {
             .update({ canceledAt: knex.fn.now() })
             .returning("*"))[0]
 
-        await module.exports.releasePhoneNumber(updatedConference.phoneNumber)
+        const conference = await module.exports.releasePhoneNumber(updatedConference.phoneNumber)
         return conference
     } catch (err) {
         console.error(`Impossible d'annuler la conférence ${id}`, err)

--- a/lib/db.js
+++ b/lib/db.js
@@ -102,18 +102,6 @@ module.exports.getConference = async (id) => {
     }
 }
 
-module.exports.getUnexpiredConference = async (id) => {
-    try {
-        const conferences = await knex('conferences').select()
-            .where({ id: id })
-            .andWhere('expiresAt', '>', new Date())
-        return conferences[0]
-    } catch (err) {
-      console.error(`Impossible de récupérer la conférence ${id}`, err)
-      throw new Error('Impossible de récupérer la conférence')
-    }
-}
-
 module.exports.cancelConference = async (id) => {
     try {
         const updatedConference = (await knex('conferences')


### PR DESCRIPTION
This logs an appropriate message when trying to show or cancel an expired conf.