### PR TITLE
Bugfix : Assign oldest free number

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -25,7 +25,7 @@ module.exports.bookNextFreePhoneNumber = async (durationInMinutes) => {
     try {
         const freePhoneNumbers = await knex('phoneNumbers').select()
             .where('freeAt', '<', knex.fn.now())
-            .orderBy('freeAt', 'desc')
+            .orderBy('freeAt', 'asc')
             .limit(1)
 
         const freePhoneNumberData = freePhoneNumbers[0]


### PR DESCRIPTION
Sur mon instance locale, le resultat de l'acienne query donne ca (on va prendre le premier de la liste pour faire la nouvelle conf): 
```
 {
    phoneNumber: '0033184253157',
    freeAt: 2020-11-05T17:22:42.438Z,
    used: 6
  },
  {
    phoneNumber: '0033184253158',
    freeAt: 2020-11-05T16:20:55.386Z,
    used: 10
  },
  {
    phoneNumber: '0033184253151',
    freeAt: 2020-11-04T14:21:30.579Z,
    used: 4
  },
.....
```

Donc il faut faire asc au lieu de desc!
Avec asc j'obtiens : 
```
{
    phoneNumber: '0033184253155',
    freeAt: 2020-11-04T01:22:48.368Z,
    used: 4
  },
  {
    phoneNumber: '0033184253156',
    freeAt: 2020-11-04T01:25:14.107Z,
    used: 2
  },
  {
    phoneNumber: '0033184253150',
    freeAt: 2020-11-04T01:28:59.599Z,
    used: 3
  },
...
```