### PR TITLE
Afficher les numéros restant sur la landing

### DIFF
--- a/views/landing.ejs
+++ b/views/landing.ejs
@@ -53,7 +53,7 @@
                 <% if (onlineParticipantsCount == 0) { %>
                 Actuellement, il reste <%= numberOfFreePhoneNumbers %> numéro<%= numberOfFreePhoneNumbers === 1 ? '' : 's' %> de conférence disponibles.
                 <% } else { %>
-                Actuellement, il y a <%= onlineParticipantsCount %> personne<%= onlineParticipantsCount > 1 ? 's' : '' %> dans <%= activeConfsCount %> conférence<%= activeConfsCount > 1 ? 's' : '' %> téléphoniques. 
+                Actuellement, il y a <%= onlineParticipantsCount %> personne<%= onlineParticipantsCount > 1 ? 's' : '' %> dans <%= activeConfsCount %> conférence<%= activeConfsCount > 1 ? 's' : '' %> téléphoniques. Il reste <%= numberOfFreePhoneNumbers %> numéro<%= numberOfFreePhoneNumbers === 1 ? '' : 's' %> de conférence disponibles. 
                 <% } %>
               <% } %>
             </p>


### PR DESCRIPTION
Améliore l'affichage des numéros restants.
C'est utile quand il reste peu de numéro.